### PR TITLE
Ensure currentPage is an int

### DIFF
--- a/dist/not-so-simple-grid.js
+++ b/dist/not-so-simple-grid.js
@@ -2762,12 +2762,18 @@ templates["text-th"] = "<div class=\"nssg-th-text\" data-bind=\"text: col.headin
         this.firstItem = propertyAsObservable(gridVM.paging, 'firstItem');
         this.lastItem = propertyAsObservable(gridVM.paging, 'lastItem');
         this.totalItems = propertyAsObservable(gridVM.paging, 'totalItems');
-        this.currentPageIndex = ko.pureComputed({ read: function () {
-            return gridVM.paging().currentPage;
-        },
+        this.currentPageIndex = ko.pureComputed({
+            read: function () {
+                return gridVM.paging().currentPage;
+            },
             write: function (newValue) {
-                gridVM.process({ paging: { currentPage: newValue } });
-            } });
+                var page = parseInt(newValue);
+                if (isNaN(page)) {
+                    page = 1;
+                }
+                gridVM.process({ paging: { currentPage: page } });
+            }
+        });
         this.pageSize = ko.pureComputed({ read: function () {
             return gridVM.paging().pageSize;
         },


### PR DESCRIPTION
If currentPageIndex is manually set from the input box it becomes a string ranther than an int. The "gotToNextPage" method will add 1 to the string value making it an invalid page number.